### PR TITLE
Altered CMakeLists.txt specifically for Mac OS Sierra 10.12.6

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 3.5)
 project(rpp)
 
 set(CMAKE_CXX_STANDARD 17)
-set(CMAKE_EXE_LINKER_FLAGS "-static")
+set(CMAKE_EXE_LINKER_FLAGS)
 
 if(NOT CMAKE_BUILD_TYPE)
     set(CMAKE_BUILD_TYPE Release)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,7 +2,9 @@ cmake_minimum_required(VERSION 3.5)
 project(rpp)
 
 set(CMAKE_CXX_STANDARD 17)
-set(CMAKE_EXE_LINKER_FLAGS)
+if(NOT APPLE) 
+	set(CMAKE_EXE_LINKER_FLAGS)
+endif()
 
 if(NOT CMAKE_BUILD_TYPE)
     set(CMAKE_BUILD_TYPE Release)


### PR DESCRIPTION
Hi Daniel, 

I made PR as suggested. The CMakeLists.txt no longer has the `static` portion. I followed the install instructions - it installs just fine with the exception of a few Warnings. I have provided a screen shot to show the warnings.
<img width="722" alt="Screen Shot 2021-03-25 at 6 25 45 PM" src="https://user-images.githubusercontent.com/14000858/112563949-8cfe8280-8d97-11eb-820b-d967f8baf7ef.png">
